### PR TITLE
added action-text to description

### DIFF
--- a/app/assets/stylesheets/actiontext.scss
+++ b/app/assets/stylesheets/actiontext.scss
@@ -1,0 +1,36 @@
+//
+// Provides a drop-in pointer for the default Trix stylesheet that will format the toolbar and
+// the trix-editor content (whether displayed or under editing). Feel free to incorporate this
+// inclusion directly in any other asset bundle and remove this file.
+//
+//= require trix/dist/trix
+@import "trix/dist/trix";
+// We need to override trix.css’s image gallery styles to accommodate the
+// <action-text-attachment> element we wrap around attachments. Otherwise,
+// images in galleries will be squished by the max-width: 33%; rule.
+.trix-content {
+  .attachment-gallery {
+    > action-text-attachment,
+    > .attachment {
+      flex: 1 0 33%;
+      padding: 0 0.5em;
+      max-width: 33%;
+    }
+
+    &.attachment-gallery--2,
+    &.attachment-gallery--4 {
+      > action-text-attachment,
+      > .attachment {
+        flex-basis: 50%;
+        max-width: 50%;
+      }
+    }
+  }
+
+  action-text-attachment {
+    .attachment {
+      padding: 0 !important;
+      max-width: 100% !important;
+    }
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,7 @@
 @import "bootstrap/scss/bootstrap";
 @import "font-awesome-sprockets";
 @import "font-awesome";
+@import "./actiontext.scss";
 
 // Your CSS partials
 @import "components/index";

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -40,3 +40,6 @@ document.addEventListener('turbolinks:load', () => {
   });
 });
 
+
+require("trix")
+require("@rails/actiontext")

--- a/app/models/experience.rb
+++ b/app/models/experience.rb
@@ -7,4 +7,5 @@ class Experience < ApplicationRecord
   validates :description, length: { in: 15..500 }
   validates :price, presence: true, numericality: { only_integer: true, greater_than: 5 }
   has_one_attached :photo
+  has_rich_text :description
 end

--- a/app/views/active_storage/blobs/_blob.html.erb
+++ b/app/views/active_storage/blobs/_blob.html.erb
@@ -1,0 +1,14 @@
+<figure class="attachment attachment--<%= blob.representable? ? "preview" : "file" %> attachment--<%= blob.filename.extension %>">
+  <% if blob.representable? %>
+    <%= image_tag blob.representation(resize_to_limit: local_assigns[:in_gallery] ? [ 800, 600 ] : [ 1024, 768 ]) %>
+  <% end %>
+
+  <figcaption class="attachment__caption">
+    <% if caption = blob.try(:caption) %>
+      <%= caption %>
+    <% else %>
+      <span class="attachment__name"><%= blob.filename %></span>
+      <span class="attachment__size"><%= number_to_human_size blob.byte_size %></span>
+    <% end %>
+  </figcaption>
+</figure>

--- a/app/views/components/_form_experiences.html.erb
+++ b/app/views/components/_form_experiences.html.erb
@@ -2,7 +2,8 @@
   <%= simple_form_for @experience do |f| %>
     <%= f.input :title %>
     <%= f.input :experience_type %>
-    <%= f.input :description %>
+    <%= f.label :description %>
+    <%= f.rich_text_area :description %>
     <%= f.input :price %>
     <%= f.input :photo, as: :file %>
     <%= f.button :submit, class: "btn btn-primary" %>

--- a/app/views/experiences/show.html.erb
+++ b/app/views/experiences/show.html.erb
@@ -1,15 +1,14 @@
 <div class="container">
   <h1><%= @experience.title %></h1>
 
-  <p>Title: <%= @experience.title %></p>
-  <p>Description: <%= @experience.description %></p>
-  <p>Price: <%= @experience.price %></p>
+  <p><%= @experience.description %></p>
+  <p>£<%= @experience.price %></p>
   <p>User: <%= @experience.user_id %></p>
   <%= link_to "See My Bookings", experience_bookings_path(@experience) %>
   <hr>
   <%= link_to "Edit Experience", edit_experience_path(@experience) %>
   <hr>
-  <%= link_to "Delete Experience", experience_path(@experience), method: :delete, data: {confirm:"chuck norris is watching you..are you sure?"} %>
+  <%= link_to "Delete Experience", experience_path(@experience), method: :delete, data: {confirm:"Are you sure you want to delete your offered experience?"} %>
   <hr>
   <%= link_to "Book Experience", new_experience_booking_path(@experience) %>
 </div>

--- a/db/migrate/20200807075143_create_action_text_tables.action_text.rb
+++ b/db/migrate/20200807075143_create_action_text_tables.action_text.rb
@@ -1,0 +1,14 @@
+# This migration comes from action_text (originally 20180528164100)
+class CreateActionTextTables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :action_text_rich_texts do |t|
+      t.string     :name, null: false
+      t.text       :body, size: :long
+      t.references :record, null: false, polymorphic: true, index: false
+
+      t.timestamps
+
+      t.index [ :record_type, :record_id, :name ], name: "index_action_text_rich_texts_uniqueness", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_06_142137) do
+ActiveRecord::Schema.define(version: 2020_08_07_075143) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "action_text_rich_texts", force: :cascade do |t|
+    t.string "name", null: false
+    t.text "body"
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["record_type", "record_id", "name"], name: "index_action_text_rich_texts_uniqueness", unique: true
+  end
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "dependencies": {
     "@rails/actioncable": "^6.0.0",
+    "@rails/actiontext": "^6.0.3-2",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
     "@rails/webpacker": "4.2.2",
@@ -10,6 +11,7 @@
     "flatpickr": "^4.6.3",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
+    "trix": "^1.2.0",
     "turbolinks": "^5.2.0"
   },
   "version": "0.1.0",

--- a/test/fixtures/action_text/rich_texts.yml
+++ b/test/fixtures/action_text/rich_texts.yml
@@ -1,0 +1,4 @@
+# one:
+#   record: name_of_fixture (ClassOfFixture)
+#   name: content
+#   body: <p>In a <i>million</i> stars!</p>

--- a/yarn.lock
+++ b/yarn.lock
@@ -807,7 +807,14 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-6.0.3.tgz#722b4b639936129307ddbab3a390f6bcacf3e7bc"
   integrity sha512-I01hgqxxnOgOtJTGlq0ZsGJYiTEEiSGVEGQn3vimZSqEP1HqzyFNbzGTq14Xdyeow2yGJjygjoFF1pmtE+SQaw==
 
-"@rails/activestorage@^6.0.0":
+"@rails/actiontext@^6.0.3-2":
+  version "6.0.3-2"
+  resolved "https://registry.yarnpkg.com/@rails/actiontext/-/actiontext-6.0.3-2.tgz#19739f5c58fed879fedcd98039baf2be0bece52d"
+  integrity sha512-X7e7mDFeQZoTyPn+Dtu+dhwWfr/9I/h+pVhsAKCithCslcefuk5q4vmlfKWyIaKYNF5j821UdR3gfI8Nwr8Wjg==
+  dependencies:
+    "@rails/activestorage" "^6.0.0-alpha"
+
+"@rails/activestorage@^6.0.0", "@rails/activestorage@^6.0.0-alpha":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@rails/activestorage/-/activestorage-6.0.3.tgz#401d2a28ecb7167cdb5e830ffddaa17c308c31aa"
   integrity sha512-YdNwyfryHlcKj7Ruix89wZ2aiN3KTYULdW1Y/hNlHJlrY2/PXjT2YBTzZiVd+dcjrwHBsXV2rExdy+Z/lsrlEg==
@@ -6970,6 +6977,11 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
   integrity sha1-WIeWa7WCpFA6QetST301ARgVphM=
+
+trix@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/trix/-/trix-1.2.4.tgz#8b8f8ea58c2605ad3d04a3b82d60a994576e33a5"
+  integrity sha512-S6YUUaaHngNbW1jzBV3MQ35pisTV/x5yKlNZrAf8exkOnHsTj+2OJHx2jBLqRQEtpWHpg85pHjo2A7dKK2RQbQ==
 
 "true-case-path@^1.0.2":
   version "1.0.3"


### PR DESCRIPTION
Hi all,

Let's discuss before merging, this adds action text to the experience description (like this comment box with formatting options).

I reset/updated my database, and the action text seems to work fine and appear once saved and updated . Just not sure exactly where it's stored, as the Experience.description in rails c is different!

I won't add the db:schema gem, as this uses the DB so I don't want to mess this up! but I can show you both later (it's useful when picking up an existing app, as you would in a job, and very simple)